### PR TITLE
Adds ability to remove teams from the sso targeted emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ if you are going to use the non-virtualised environment , you need following too
 
     GITHUB_LOGIN=<GitHubLogin>
     GITHUB_AUTH_TOKEN=<GithubAuthToken>
-
+    GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET=<list of teams not part of sso target i.e. users of those team will not receive an automatic vulnerability report>
     SLACK_URL=<Slack Post Message Url>
     SLACK_AUTH_TOKEN=<Slack Test Auth Token>
     SLACK_CHANNEL=<Slack Test Channel Code>

--- a/all_vars.env
+++ b/all_vars.env
@@ -24,6 +24,8 @@ GITHUB_API_URL = "https://api.github.com/graphql"
 GITHUB_FIRST_N_RECORDS = 100
 GITHUB_VERIFY_SSL = True
 GITHUB_SKIP_SCAN_TOPIC ="skip-vulnerability-scan"
+#This represents the list of teams, which will not be used for sending out SSO target email, that is members of this team will not receive automaic report
+GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET='team1,team2'
 
 # SCANNER Variable
 SCANNER_DATA_FILE_NAME = ".scanner_data.json"

--- a/config/settings.py
+++ b/config/settings.py
@@ -62,7 +62,9 @@ GITHUB_VERIFY_SSL = env.bool("GITHUB_VERIFY_SSL", default=True)
 GITHUB_SKIP_SCAN_TOPIC = env(
     "GITHUB_SKIP_SCAN_TOPIC", default="skip-vulnerability-scan"
 )
-
+GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET = env.list(
+    "GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET", default=[]
+)
 # SCANNER Variable
 SCANNER_DATA_FILE_NAME = env("SCANNER_DATA_FILE_NAME", default=".scanner_data.json")
 SCANNER_DATA_FILE_PATH = Path.joinpath(BASE_DIR, SCANNER_DATA_FILE_NAME)

--- a/report/db.py
+++ b/report/db.py
@@ -127,9 +127,15 @@ def get_reportable_teams_from_db():
 
 
 def get_team_notification_targets(team):
-    return SAMLNotificationTarget.objects.filter(team=team).union(
-        TeamNotificationTarget.objects.filter(team=team)
-    )
+
+    saml_targets = SAMLNotificationTarget.objects.filter(team=team).exclude(email="")
+    team_targets = TeamNotificationTarget.objects.filter(team=team).exclude(email="")
+
+    return saml_targets.union(team_targets)
+
+    # return SAMLNotificationTarget.objects.filter(team=team).union(
+    #     TeamNotificationTarget.objects.filter(team=team)
+    # )
 
 
 def get_organization_notification_targets():

--- a/report/processor.py
+++ b/report/processor.py
@@ -14,6 +14,7 @@ from config.severities import (
 
 from collections import Counter
 from copy import deepcopy
+from django.conf import settings
 
 
 class ReportDataProcessor:
@@ -196,6 +197,9 @@ class ReportDataProcessor:
                 self._processed_data_store["sso_notification_targets"].update(
                     {team: {}}
                 )
+
+            if team in settings.GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET:
+                continue
 
             for member in members:
                 if member in known_users:

--- a/report/tests/conftest.py
+++ b/report/tests/conftest.py
@@ -25,6 +25,9 @@ import pytest
 from copy import deepcopy
 
 
+settings.GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET = ["team1"]
+
+
 @singleton
 class MockScannerData:
     """

--- a/report/tests/db/unit/test_get_notification_targets.py
+++ b/report/tests/db/unit/test_get_notification_targets.py
@@ -15,7 +15,7 @@ def test_test_get_team_notification_target(db):
         Team(name=team_name).save()
 
     for team in get_teams_from_db():
-        TeamNotificationTarget(team=team).save()
+        TeamNotificationTarget(team=team, email=f"{team}@test.done").save()
 
     for team_name in teams:
         target_team = get_team_notification_targets(team=team_name)

--- a/report/tests/db/unit/test_update_sso_notification_targets.py
+++ b/report/tests/db/unit/test_update_sso_notification_targets.py
@@ -64,15 +64,15 @@ def test_update_sso_notification_targets_in_db_with_delete_user(
     update_teams_in_db(github_teams=list(report_reader.teams.keys()))
     update_sso_notification_targets_in_db(sso_notification_targets=notification_targets)
 
-    logins = list(notification_targets["team1"].keys())
+    logins = list(notification_targets["team3"].keys())
 
     del_login = logins[0]
-    del notification_targets["team1"][del_login]
+    del notification_targets["team3"][del_login]
 
     update_sso_notification_targets_in_db(sso_notification_targets=notification_targets)
 
     logins_in_db = list(
-        SAMLNotificationTarget.objects.filter(team="team1").values_list(
+        SAMLNotificationTarget.objects.filter(team="team3").values_list(
             "login", flat=True
         )
     )

--- a/report/tests/processor/unit/test_add_sso_notification_targets.py
+++ b/report/tests/processor/unit/test_add_sso_notification_targets.py
@@ -16,8 +16,9 @@ def test_add_sso_notification_targets(processor, scene_index, scene_data):
 
 def check_sso_notification_targets(sso_notification_targets):
 
-    assert "user1" in sso_notification_targets["team1"]
-    assert "user2" in sso_notification_targets["team1"]
+    assert "user1" not in sso_notification_targets["team1"]
+    assert "user2" not in sso_notification_targets["team1"]
+    assert len(sso_notification_targets["team1"]) == 0
 
     assert "user2" in sso_notification_targets["team2"]
     assert "user3" in sso_notification_targets["team2"]


### PR DESCRIPTION
- useful in event like when, everyone in org is part of the team and, it may be not appropriate to send them vulnerability emails
- it takes list of teams exempted via environment variable GITHUB_TEAMS_ARE_NOT_A_SSO_TARGET